### PR TITLE
Local tag consistency and pytest import in tc300

### DIFF
--- a/settings.conf
+++ b/settings.conf
@@ -12,8 +12,8 @@ SCHEMAREGISTRY_IMG=confluentinc/cp-schema-registry:7.3.0
 REDIS_IMG=redis
 
 # TRAFFIC REPRODUCER IMAGES
-TRAFFIC_REPRO_IMG=traffic-reproducer:dev
-TRAFFIC_REPRO_MULTI_IMG=traffic-reproducer-multi:dev
+TRAFFIC_REPRO_IMG=traffic-reproducer:local
+TRAFFIC_REPRO_MULTI_IMG=traffic-reproducer-multi:local
 
 # NFACCTD IMAGE
 #PMACCT_NFACCTD_IMG=pmacct/nfacctd:bleeding-edge

--- a/tests/300-BGP-IPv6-CISCO-extNH_enc/300_test.py
+++ b/tests/300-BGP-IPv6-CISCO-extNH_enc/300_test.py
@@ -2,7 +2,7 @@
 from library.py.setup_tools import KModuleParams
 import library.py.scripts as scripts
 import library.py.helpers as helpers
-import logging, sys
+import logging, pytest, sys
 import library.py.test_tools as test_tools
 logger = logging.getLogger(__name__)
 

--- a/tools/pcap_player/build_docker_images.sh
+++ b/tools/pcap_player/build_docker_images.sh
@@ -5,5 +5,5 @@ IMG=debian
 SCRIPT_DIR=$( cd -- "$( dirname -- "$0" )" &> /dev/null && pwd )
 
 echo "Building traffic reproducer docker images"
-docker build -t traffic-reproducer -f $SCRIPT_DIR/single/Dockerfile_$IMG $SCRIPT_DIR || exit $?
-docker build -t traffic-reproducer-multi -f $SCRIPT_DIR/multi/Dockerfile_$IMG $SCRIPT_DIR || exit $?
+docker build -t traffic-reproducer:local -f $SCRIPT_DIR/single/Dockerfile_$IMG $SCRIPT_DIR || exit $?
+docker build -t traffic-reproducer-multi:local -f $SCRIPT_DIR/multi/Dockerfile_$IMG $SCRIPT_DIR || exit $?


### PR DESCRIPTION
When I cloned and built from scratch, I faced these issues, which I fixed:
- Image tag "dev" was used in settings.conf for the traffic-reproducer images, whereas no tag was used in the build scripts. Changed both to local.
- pytest library was not imported in test case 300