### PR TITLE
Pcap folders accumulating across scenarios

### DIFF
--- a/library/py/setup_tools.py
+++ b/library/py/setup_tools.py
@@ -254,6 +254,7 @@ def prepare_pcap_folder(params, i, test_config_file, test_pcap_file):
 # Prepares json output, log, pcap and pcap-config files
 def prepare_pcap(_module):
     params = _module.testParams
+    params.pcap_folders.clear()
     test_config_files = select_files(params.test_folder, 'traffic-reproducer.*-\\d+.yml$')
     test_pcap_files = select_files(params.test_folder, 'traffic.*-\\d+.pcap$')
     assert len(test_pcap_files)==len(test_config_files)


### PR DESCRIPTION
Since the testParams variable is shared across test scenarios (it lives at module level), just appending items to the pcap_folders property causes them to accumulate. As a consequence, when both the default scenario and scenario_1 are selected for execution in a row, scenario_1 may use default's pcap folder and therefore uses default's docker-compose.yml file. Therefore, the path of the volume mounted to traffic-reproducer container may be the wrong one (may be the one belonging to default).
As a fix, pcap_folders property of testParams is now reset (the list is cleared) before being (re/)populated in each scenario.