### PR TITLE
Added binary pre-deserialization Kafka dumps for debugging; introduced AvroDeserializer

### DIFF
--- a/library/py/script_tools.py
+++ b/library/py/script_tools.py
@@ -5,7 +5,7 @@
 # nikolaos.tsokas@swisscom.com 26/02/2023
 ###################################################
 
-import subprocess, time, logging, os, signal
+import subprocess, time, logging
 from typing import List, Callable, Tuple
 logger = logging.getLogger(__name__)
 

--- a/library/py/setup_tools.py
+++ b/library/py/setup_tools.py
@@ -40,12 +40,13 @@ class KModuleParams:
         self.test_output_files = select_files(self.test_folder, 'output.*-\\d+.json$')
         self.test_log_files = select_files(self.test_folder, 'output.*-\\d+.txt$')
 
-    # Sets subfolder of test results folder. This is run once for the deault scenario.
+    # Sets subfolder of test results folder. This is run once for the default scenario.
     # If it is determined that it is about a specific scenario, this function is re-executed (see function below)
     def set_results_folders(self):
         self.pmacct_docker_compose_file = self.results_folder + '/docker-compose-pmacct.yml'
         self.results_conf_file = self.results_folder + '/' + self.daemon + '.conf'
         self.results_mount_folder = self.results_folder + '/pmacct_mount'
+        self.results_dump_folder = self.results_folder + '/kafka_dumps'
         self.results_output_folder = self.results_mount_folder + '/pmacct_output'
         self.pmacct_log_file = self.results_output_folder + '/pmacctd.log'
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
-filterwarnings =
-    ignore:.*deprecated*:DeprecationWarning
+#filterwarnings =
+#    ignore:.*deprecated*:DeprecationWarning
 
 log_cli = true
 log_cli_level = INFO

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@
 
 import library.py.scripts as scripts
 import library.py.setup_tools as setup_tools
-import logging, pytest, os, re
+import logging, pytest, os
 import library.py.helpers as helpers
 from library.py.kafka_consumer import KMessageReaderAvro, KMessageReaderPlainJson, KMessageReaderList
 logger = logging.getLogger(__name__)
@@ -170,12 +170,13 @@ def prepare_pcap(request):
 def setup_consumers(request):
     params = request.module.testParams
     consumers = KMessageReaderList()
+    os.makedirs(params.results_dump_folder)
     for k in params.kafka_topics.keys():
         topic_name = '_'.join(params.kafka_topics[k].split('.')[0:-1])
         messageReaderClass = KMessageReaderAvro
         if topic_name.endswith('_json'):
             messageReaderClass = KMessageReaderPlainJson
-        msg_dump_file = params.results_folder + '/' + topic_name + '_dump.json'
+        msg_dump_file = params.results_dump_folder + '/' + topic_name + '_dump'
         consumer = messageReaderClass(params.kafka_topics[k], msg_dump_file)
         consumer.connect()
         consumers.append(consumer)


### PR DESCRIPTION
Enhancements to Kafka consumption:
- Kafka incoming messages are now dumped in binary (and binary-text) format before deserialisation; this helps with debugging
- In class KMessageReaderAvro, AvroConsumer was replaced by simple Consumer and an AvroDeserializer, as prompted by the Confluent Deprecation Warning
- Now the framework dumps all incoming Kafka topics in three different formats/files: (a) json format, as previously, (.json) (b) binary format (.dat), (c) readable binary-text format (.txt)
- Kafka dumps are now saved in a separate folder "kafka_dumps" inside the results folder of the test case
- Deprecation warning suppression removed from pytest.ini (since AvroConsumer Deprecation Warning was eliminated)
Included are also a couple of cosmetic changes (comments, unused imports)